### PR TITLE
Add frame element to nonLinePendulum test example

### DIFF
--- a/examples/nonlinearPendulum/onsasExample_nonlinearPendulum.m
+++ b/examples/nonlinearPendulum/onsasExample_nonlinearPendulum.m
@@ -66,7 +66,7 @@ otherParams.problemName     = 'nonlinearPendulumHHTTrussBathe';
 % ------------------------------------
 [matUsCase2, loadFactorsMat] = ONSAS( materials, elements, boundaryConds, initialConds, mesh, analysisSettings, otherParams ) ;
 
-runFrameValidation = 1;
+runFrameValidation = 0;
     if runFrameValidation
     %md### Analysis case 3: Solution using HHT with truss element and mass conssitent
     analysisSettings.finalTime  = 3.4124;
@@ -110,8 +110,9 @@ end
 
 %mdCompute time of vectors
 timesVec12  = (0:length(controlDispZCase1)-1) * analysisSettings.deltaT ;
+if runFrameValidation
 timesVec34  = (0:length(controlDispZCase3)-1) * analysisSettings.deltaT ;
-
+end
 
 %md## verification
 %md### verif newmark and HHT method using uz(N*T)= 0 with lumped mass matrix

--- a/examples/nonlinearPendulum/onsasExample_nonlinearPendulum.m
+++ b/examples/nonlinearPendulum/onsasExample_nonlinearPendulum.m
@@ -1,4 +1,3 @@
-
 close all, clear all ; addpath( genpath( [ pwd '/../../src'] ) );
 %md## Numerical solution
 %mdExample of nolinear equaitons in dynamic analyisis section of Bathe pag 827
@@ -111,7 +110,7 @@ end
 %mdCompute time of vectors
 timesVec12  = (0:length(controlDispZCase1)-1) * analysisSettings.deltaT ;
 if runFrameValidation
-timesVec34  = (0:length(controlDispZCase3)-1) * analysisSettings.deltaT ;
+    timesVec34  = (0:length(controlDispZCase3)-1) * analysisSettings.deltaT ;
 end
 
 %md## verification
@@ -126,7 +125,6 @@ if runFrameValidation
 else
     verifBoolean    = verifBooleanCase1 && verifBooleanCase2 ;
 end
-
 
 %md### Plots
 %md


### PR DESCRIPTION
New exection time of this example is 35.4 s vs old execution time (without frame and truss conssitent examples)
 was 8.5 s

Screenshot:
![newExecTime](https://user-images.githubusercontent.com/50339940/141173028-689a8d80-6b0c-49fa-8586-803f0622dbd9.png)
