### PR TITLE
added fs boolean in assembler 

### DIFF
--- a/src/ONSAS_init.m
+++ b/src/ONSAS_init.m
@@ -51,7 +51,7 @@ currTime         = 0 ; timeIndex        = 1 ; convDeltau      = zeros( size(U) )
 timeStepIters    = 0 ; timeStepStopCrit = 0 ;
 
 %md call assembler
-[~, Stress ] = assembler ( Conec, elements, Nodes, materials, KS, U, Udot, Udotdot, analysisSettings, [ 0 1 0 ], otherParams.nodalDispDamping, analysisSettings.deltaT ) ;
+[~, Stress ] = assembler ( Conec, elements, Nodes, materials, KS, U, Udot, Udotdot, analysisSettings, [ 0 1 0 ], otherParams.nodalDispDamping, currTime ) ;
 
 systemDeltauMatrix = computeMatrix( Conec, elements, Nodes, materials, KS, analysisSettings, U, Udot, Udotdot, neumDofs, otherParams.nodalDispDamping ) ;
 

--- a/src/aeroForce.m
+++ b/src/aeroForce.m
@@ -193,23 +193,23 @@ function integAeroForce = integAeroForce( x, ddotg, udotWindElem,
   % proyect velocity and chord vector into transverse plane
   VrelG       = udotWindG - udotG  ;
   if battiBool || jorgeBool || jorgeBoolRigid ;
-;    VpiRelG   = L2 * RgGx' * VrelG ;
+    VpiRelG   = L2 * RgGx' * VrelG ;
   elseif rigidBool 
     VpiRelG   = L2 * Rr' * VrelG ;
   end
   VpiRelGperp = L3 * VpiRelG       ;
-  % Calculate relative incidence angle
-  if( norm( VpiRelG) == 0)
-      fprintf('WARNING: Relative velocity is zero \n')
-      td = [0, 0, 1];%define random vector to compute zero force
-  else
-      td = VpiRelG / norm( VpiRelG ) ;
-  end
   % rotate chord vector
   if battiBool || jorgeBool || jorgeBoolRigid ;
 ;    tch = R0 * RgGx * vecChordUndef / norm( vecChordUndef ) ;
   elseif rigidBool
     tch = Rroofx * vecChordUndef / norm( vecChordUndef ) ;
+  end
+  % Calculate relative incidence angle
+  if( norm( VpiRelG) == 0 )
+      % fprintf('WARNING: Relative velocity is zero \n')
+      td = tch;%define tch equal to td if vRel is zero to compute force with zero angle of attack
+  else
+      td = VpiRelG / norm( VpiRelG ) ;
   end
   scalarProduct   = dot( tch ,td ) ; 
   betaRelG = acos ( scalarProduct / ( norm (tch) * norm(td) ) );

--- a/src/assembler.m
+++ b/src/assembler.m
@@ -150,7 +150,7 @@ for elem = 1:nElems
     if AeroCoefficentsBool &&  aeroBool == 0
       error("elemTypeAero chord vector must be defined in elements struct \n")
     end
-    if aeroBool
+    if aeroBool && fsBool
       % extract wind function name
       userWindVel = analysisSettings.userWindVel ;
       % extract nonLinearity in aero force boolean


### PR DESCRIPTION
This PR changes:

- [x]  initial time calling to assembler.
- [x] added `fs boolean` to not compute aerodynamic force unnecessary
- [x] select null angle of attack if velocity is zero and no plot warning, since most examples start with null velocity

Closes #350 