### PR TITLE
Global variables to store reaction forces

### DIFF
--- a/examples/reconfigurationBeam/circularReconfiguration.m
+++ b/examples/reconfigurationBeam/circularReconfiguration.m
@@ -87,10 +87,12 @@ end
 %md---------------------
 %md Declare a global variable to store drag 
 %
-global globalFDrag
+global globalReactionForces
+global glboalNodeReactionForces
 global globalNIter
-globalFDrag = zeros(analysisSettings.finalTime, 1) ;
-globalNIter = zeros(analysisSettings.finalTime + 1, 1) ;
+globalReactionForces = zeros(6*analysisSettings.finalTime, 1) ;
+globalNIter = zeros(analysisSettings.finalTime + 1, 1)        ;
+glboalNodeReactionForces = 1                                  ;
 %
 % Run ONSAS 
 %
@@ -121,7 +123,8 @@ for windVelStep = 1:numLoadSteps - 1
     Cy(windVelStep) =  1/2 * rhoF * normWindVel^2 * (l)^3 *d / (E*Izz)                        ;
 
     % numeric drag 
-    FDragi = globalFDrag(windVelStep)                 ;
+    FReaction = globalReactionForces((windVelStep-1)*6 + 1: windVelStep*6)                 ;
+    FDragi = FReaction(3) ;
     FDRef  = 1/2 * rhoF * normWindVel^2 * C_d * d * l ;
     R(windVelStep) =  abs(FDragi)/(FDRef )            ;
 

--- a/src/core/assembler.m
+++ b/src/core/assembler.m
@@ -350,10 +350,11 @@ if fsBool
   fsCell{3} = Fmas  ;
   fsCell{4} = Faero ;
 
-
-  global globalFDrag
-  if ~isempty(globalFDrag) && (round(timeVar) == timeVar) && (timeVar ~= 0)
-    globalFDrag(timeVar) = sum(Faero(3:6:end)) ;
+  global globalReactionForces
+  global nodeReactionForces
+  if ~isempty(globalReactionForces) && (round(timeVar) == timeVar) && (timeVar ~= 0)
+    dofsRForces = (nodeReactionForces - 1) * 6 + 1 : nodeReactionForces * 6  ;
+    globalReactionForces((timeVar -1)*6 + 1: (timeVar)*6) = Faero(dofsRForces) - Fint(dofsRForces) - Fmas(dofsRForces) - Fvis(dofsRForces) ;
   end
 end
 

--- a/src/core/assembler.m
+++ b/src/core/assembler.m
@@ -351,11 +351,12 @@ if fsBool
   fsCell{4} = Faero ;
 
   global globalReactionForces
-  global nodeReactionForces
+  global glboalNodeReactionForces
   if ~isempty(globalReactionForces) && (round(timeVar) == timeVar) && (timeVar ~= 0)
-    dofsRForces = (nodeReactionForces - 1) * 6 + 1 : nodeReactionForces * 6  ;
+    dofsRForces = (glboalNodeReactionForces - 1) * 6 + 1 : glboalNodeReactionForces * 6  ;
     globalReactionForces((timeVar -1)*6 + 1: (timeVar)*6) = Faero(dofsRForces) - Fint(dofsRForces) - Fmas(dofsRForces) - Fvis(dofsRForces) ;
   end
+
 end
 
 


### PR DESCRIPTION
This pull request aims to generalize the `globalFDrag` variable. Now two global variables are added:

-  ` globalReactionForces` a global variable to store the reaction forces $t = [1, 2, ...]$ s.
- `glboalNodeReactionForces` a global variable to indicate in which node the reaction forces are being stored.     